### PR TITLE
Set proper value for taxonomy element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kentico-cloud-graphql-schema-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "GraphQL schema generator used to generate schema based on specified project.",
   "main": "_commonjs/index.js",
   "bin": {

--- a/src/__tests__/data/fakeEmptyTypes.output.txt
+++ b/src/__tests__/data/fakeEmptyTypes.output.txt
@@ -62,7 +62,7 @@ type UrlSlugElement {
 type TaxonomyElement {
   type: String!
   name: String!
-  value: [String]
+  value: [TaxonomyTerm]
   taxonomyGroup: String
   taxonomyTerms: [TaxonomyTerm]
 }

--- a/src/__tests__/data/fakeEmptyTypes.output.txt
+++ b/src/__tests__/data/fakeEmptyTypes.output.txt
@@ -62,7 +62,7 @@ type UrlSlugElement {
 type TaxonomyElement {
   type: String!
   name: String!
-  value: String
+  value: [String]
   taxonomyGroup: String
   taxonomyTerms: [TaxonomyTerm]
 }

--- a/src/__tests__/data/fakeTypesComplex.output.txt
+++ b/src/__tests__/data/fakeTypesComplex.output.txt
@@ -62,7 +62,7 @@ type UrlSlugElement {
 type TaxonomyElement {
   type: String!
   name: String!
-  value: [String]
+  value: [TaxonomyTerm]
   taxonomyGroup: String
   taxonomyTerms: [TaxonomyTerm]
 }

--- a/src/__tests__/data/fakeTypesComplex.output.txt
+++ b/src/__tests__/data/fakeTypesComplex.output.txt
@@ -62,7 +62,7 @@ type UrlSlugElement {
 type TaxonomyElement {
   type: String!
   name: String!
-  value: String
+  value: [String]
   taxonomyGroup: String
   taxonomyTerms: [TaxonomyTerm]
 }

--- a/src/graphql-schema-model.ts
+++ b/src/graphql-schema-model.ts
@@ -160,7 +160,7 @@ export class GraphQLSchemaModel {
       `type ${GraphQLSchemaModel.taxonomyElementTypeName} {
   type: String!
   name: String!
-  value: [String]
+  value: [TaxonomyTerm]
   taxonomyGroup: String
   taxonomyTerms: [TaxonomyTerm]
 }`,

--- a/src/graphql-schema-model.ts
+++ b/src/graphql-schema-model.ts
@@ -160,7 +160,7 @@ export class GraphQLSchemaModel {
       `type ${GraphQLSchemaModel.taxonomyElementTypeName} {
   type: String!
   name: String!
-  value: String
+  value: [String]
   taxonomyGroup: String
   taxonomyTerms: [TaxonomyTerm]
 }`,


### PR DESCRIPTION
### Motivation

Value of the type `TaxonomyElement` was set as a string, but it is an array of the object with name and codename (both strings) - which is the type `TaxonomyTerm`

```
"personas": {
          "type": "taxonomy",
          "name": "Personas",
          "taxonomy_group": "personas",
          "value": [
            {
              "name": "Barista",
              "codename": "barista"
            },
            {
              "name": "Coffee blogger",
              "codename": "coffee_blogger"
            }
          ]
        }
```

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
